### PR TITLE
Fix button label in Recurrent Expenses tab

### DIFF
--- a/frontend/components/recurrent-expenses/index.tsx
+++ b/frontend/components/recurrent-expenses/index.tsx
@@ -1015,7 +1015,7 @@ export function RecurrentExpenses() {
           setAddOpen(true);
         }}
       >
-        + New Template
+        + New Recurrent Expense
       </button>
 
       {/* Trashed section (admin only) */}


### PR DESCRIPTION
Rename the '+ New Template' button to '+ New Recurrent Expense' to accurately reflect its purpose.