### PR TITLE
Allow editing the payment method of a cycle expense

### DIFF
--- a/backend/app/cycles/schemas.py
+++ b/backend/app/cycles/schemas.py
@@ -198,6 +198,7 @@ class CycleExpenseUpdate(AppBaseModel):
     status: ExpenseStatus | None = None
     paid: bool | None = None
     paid_at: datetime | None = None
+    payment_method_id: uuid.UUID | None = None
     comments: str | None = Field(None, max_length=1000)
     autopay: bool = False
 
@@ -239,6 +240,7 @@ class CycleExpenseResponse(BaseModel):
     comments: str | None
     autopay: bool
     template_id: uuid.UUID | None
+    payment_method_id: uuid.UUID
     payment_method: PaymentMethodSummary
     created_at: datetime
     updated_at: datetime

--- a/backend/app/cycles/service.py
+++ b/backend/app/cycles/service.py
@@ -943,6 +943,11 @@ class CycleExpenseService:
             stripped = (raw or "").strip()
             new_comment_body = stripped or None
 
+        if update_data.get("payment_method_id"):
+            _verify_payment_method(
+                db, update_data["payment_method_id"], str(cycle.household_id)
+            )
+
         # Keep paid / status / paid_at in sync
         if "paid" in update_data:
             if update_data["paid"] and "paid_at" not in update_data:

--- a/backend/tests/cycles/test_expense_update.py
+++ b/backend/tests/cycles/test_expense_update.py
@@ -1,0 +1,145 @@
+"""Tests for PUT /api/v1/cycles/{cycle_id}/expenses/{expense_id}.
+
+Focused on changing the payment method of an expense already in a cycle.
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.auth.models import User
+from app.cycles.models import Cycle, CycleExpense
+from app.households.models import Household
+from app.payment_methods.constants import (
+    CurrencyCode as PMCurrencyCode,
+    PaymentMethodType,
+)
+from app.payment_methods.models import PaymentMethod
+
+
+def get_auth_headers(client: TestClient, user: User) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/login",
+        data={"username": user.username, "password": "testpassword123"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _first_expense(cycle: Cycle) -> CycleExpense:
+    """Return a pending USD expense from the seeded cycle."""
+    return next(e for e in cycle.expenses if e.description == "Groceries")
+
+
+class TestUpdateExpensePaymentMethod:
+    def test_requires_auth(
+        self, client: TestClient, cycle_with_expenses: Cycle
+    ) -> None:
+        expense = _first_expense(cycle_with_expenses)
+        response = client.put(
+            f"/api/v1/cycles/{cycle_with_expenses.id}/expenses/{expense.id}",
+            json={"payment_method_id": str(uuid.uuid4())},
+        )
+        assert response.status_code == 401
+
+    def test_changes_payment_method(
+        self,
+        client: TestClient,
+        test_user: User,
+        cycle_with_expenses: Cycle,
+        mxn_payment_method: PaymentMethod,
+    ) -> None:
+        headers = get_auth_headers(client, test_user)
+        expense = _first_expense(cycle_with_expenses)
+        assert expense.payment_method_id != mxn_payment_method.id
+
+        response = client.put(
+            f"/api/v1/cycles/{cycle_with_expenses.id}/expenses/{expense.id}",
+            headers=headers,
+            json={"payment_method_id": str(mxn_payment_method.id)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # The response must echo the new id at the top level so the UI can
+        # re-initialize its dropdown after save (regression: it previously
+        # only returned the nested payment_method object).
+        assert data["payment_method_id"] == str(mxn_payment_method.id)
+        assert data["payment_method"]["id"] == str(mxn_payment_method.id)
+
+    def test_unknown_payment_method_rejected(
+        self,
+        client: TestClient,
+        test_user: User,
+        cycle_with_expenses: Cycle,
+    ) -> None:
+        headers = get_auth_headers(client, test_user)
+        expense = _first_expense(cycle_with_expenses)
+
+        response = client.put(
+            f"/api/v1/cycles/{cycle_with_expenses.id}/expenses/{expense.id}",
+            headers=headers,
+            json={"payment_method_id": str(uuid.uuid4())},
+        )
+
+        assert response.status_code == 404
+
+    def test_other_household_payment_method_rejected(
+        self,
+        client: TestClient,
+        db: Session,
+        test_user: User,
+        cycle_with_expenses: Cycle,
+        other_household: Household,
+    ) -> None:
+        headers = get_auth_headers(client, test_user)
+        expense = _first_expense(cycle_with_expenses)
+        foreign_pm = PaymentMethod(
+            household_id=other_household.id,
+            name="Foreign Card",
+            method_type=PaymentMethodType.CREDIT,
+            default_currency=PMCurrencyCode.USD,
+        )
+        db.add(foreign_pm)
+        db.commit()
+        db.refresh(foreign_pm)
+
+        response = client.put(
+            f"/api/v1/cycles/{cycle_with_expenses.id}/expenses/{expense.id}",
+            headers=headers,
+            json={"payment_method_id": str(foreign_pm.id)},
+        )
+
+        assert response.status_code == 404
+
+    def test_change_is_recorded_in_activity_log(
+        self,
+        client: TestClient,
+        test_user: User,
+        cycle_with_expenses: Cycle,
+        usd_payment_method: PaymentMethod,
+        mxn_payment_method: PaymentMethod,
+    ) -> None:
+        headers = get_auth_headers(client, test_user)
+        expense = _first_expense(cycle_with_expenses)
+
+        update = client.put(
+            f"/api/v1/cycles/{cycle_with_expenses.id}/expenses/{expense.id}",
+            headers=headers,
+            json={"payment_method_id": str(mxn_payment_method.id)},
+        )
+        assert update.status_code == 200
+
+        activity = client.get(
+            "/api/v1/activity/",
+            headers=headers,
+            params={"entity_type": "cycle_expense", "entity_id": str(expense.id)},
+        )
+        assert activity.status_code == 200
+        entries = activity.json()
+        pm_change = next(e for e in entries if "payment_method_id" in e["changes"])
+        diff = pm_change["changes"]["payment_method_id"]
+        assert diff["from"] == str(usd_payment_method.id)
+        assert diff["to"] == str(mxn_payment_method.id)

--- a/docs/architecture/api-specification.md
+++ b/docs/architecture/api-specification.md
@@ -714,6 +714,7 @@ with status `paid` and `paid_at` set to the current timestamp.
   "paid_at": null,
   "autopay": false,
   "template_id": null,
+  "payment_method_id": "123e4567-e89b-12d3-a456-426614174002",
   "payment_method": {
     "id": "123e4567-e89b-12d3-a456-426614174002",
     "name": "Capital One Credit",
@@ -728,15 +729,18 @@ with status `paid` and `paid_at` set to the current timestamp.
 Get a specific expense.
 
 #### PUT /cycles/{cycle_id}/expenses/{expense_id}
-Update an expense.
+Update an expense. All fields are optional; only the fields provided are
+changed. The `payment_method_id` must reference an active payment method in
+the same household, and the change is recorded in the activity log.
 
 **Request Body:**
 ```json
 {
   "amount": "375.00",
+  "payment_method_id": "123e4567-e89b-12d3-a456-426614174002",
   "paid": true,
   "paid_at": "2025-01-15T14:30:00Z",
-  "comments": "Updated amount and marked as paid"
+  "comments": "Updated amount, payment method, and marked as paid"
 }
 ```
 

--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -147,7 +147,7 @@ Write tools — cycle creation, plus cycle expenses and incomes:
 | `mark_expense_paid_other` | Mark an expense as paid by other means (off-budget) |
 | `reset_expense_to_pending` | Undo a skip or "paid (other)" mark, back to pending |
 | `add_cycle_expense` | Add a new expense to a cycle |
-| `update_cycle_expense` | Update fields on a cycle expense |
+| `update_cycle_expense` | Update fields on a cycle expense (amount, due date, category, payment method, comments, paid) |
 | `add_cycle_income` | Record a new income in a cycle |
 | `update_cycle_income` | Update fields on a cycle income |
 

--- a/frontend/components/activity/index.tsx
+++ b/frontend/components/activity/index.tsx
@@ -12,8 +12,10 @@ import type {
   CycleIncome,
   EntityType,
   ExpenseStatus,
+  PaymentMethod,
   UserResponse,
 } from "@/helpers/types";
+import { formatPaymentMethodName } from "@/helpers/formatters";
 
 import {
   addComment,
@@ -47,6 +49,11 @@ interface ActivityFeedProps {
    */
   expenses?: CycleExpense[];
   incomes?: CycleIncome[];
+  /**
+   * Optional payment methods used to resolve `payment_method_id` change
+   * diffs to readable names instead of raw UUIDs.
+   */
+  paymentMethods?: PaymentMethod[];
 }
 
 const EXPENSE_STATUS_LABEL: Record<ExpenseStatus, string> = {
@@ -132,6 +139,7 @@ const CHANGE_KEY_LABEL: Record<string, string> = {
   comments: "Comments",
   active: "Active",
   name: "Name",
+  payment_method_id: "Payment method",
 };
 
 function humanizeKey(key: string): string {
@@ -156,25 +164,36 @@ function fmtDateTime(iso: string): string {
   });
 }
 
-function fmtChangeValue(key: string, value: unknown): string {
+function fmtChangeValue(
+  key: string,
+  value: unknown,
+  pmNames?: Map<string, string>,
+): string {
   if (value === null || value === undefined || value === "") return "—";
   if (typeof value === "string") {
     if (key.endsWith("_at")) return fmtDateTime(value);
     if (key.endsWith("_date")) return fmtShortDate(value);
+    // Resolve payment method UUIDs to readable names; fall back to the raw
+    // value (e.g. a method that has since been deactivated and isn't in the
+    // provided list).
+    if (key === "payment_method_id") return pmNames?.get(value) ?? value;
   }
   return String(value);
 }
 
-function renderChanges(changes: Record<string, ActivityChange>): string | null {
+function renderChanges(
+  changes: Record<string, ActivityChange>,
+  pmNames?: Map<string, string>,
+): string | null {
   const keys = Object.keys(changes).filter((k) => k !== "comment_id");
   if (keys.length === 0) return null;
   return keys
     .map((k) => {
       const v = changes[k];
       if (isDiff(v)) {
-        return `${humanizeKey(k)}: ${fmtChangeValue(k, v.from)} → ${fmtChangeValue(k, v.to)}`;
+        return `${humanizeKey(k)}: ${fmtChangeValue(k, v.from, pmNames)} → ${fmtChangeValue(k, v.to, pmNames)}`;
       }
-      return `${humanizeKey(k)}: ${fmtChangeValue(k, v)}`;
+      return `${humanizeKey(k)}: ${fmtChangeValue(k, v, pmNames)}`;
     })
     .join(", ");
 }
@@ -220,6 +239,7 @@ export function ActivityFeed({
   onCommentMutated,
   expenses = [],
   incomes = [],
+  paymentMethods = [],
 }: ActivityFeedProps) {
   const [entries, setEntries] = useState<ActivityEntry[]>([]);
   const [comments, setComments] = useState<CommentType[]>([]);
@@ -301,6 +321,9 @@ export function ActivityFeed({
   // Hydrate cycle_expense / cycle_income rows from the parent-provided lists.
   const expenseById = new Map(expenses.map((e) => [e.id, e]));
   const incomeById = new Map(incomes.map((i) => [i.id, i]));
+  const pmNames = new Map(
+    paymentMethods.map((m) => [m.id, formatPaymentMethodName(m)]),
+  );
 
   const filtered = showOnlyComments
     ? entries.filter((e) => e.action === "commented")
@@ -426,7 +449,7 @@ export function ActivityFeed({
                       <IncomeCard income={incomeById.get(entry.entity_id)!} />
                     )}
                   <div className="nb-activity-changes">
-                    {renderChanges(entry.changes)}
+                    {renderChanges(entry.changes, pmNames)}
                   </div>
                 </>
               )}

--- a/frontend/components/cycles/index.tsx
+++ b/frontend/components/cycles/index.tsx
@@ -1,10 +1,6 @@
 "use client";
 import Link from "next/link";
-import {
-  useRouter,
-  useSearchParams,
-  usePathname,
-} from "next/navigation";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
 import type {
   Cycle,
@@ -377,6 +373,7 @@ function ExpenseRow({
 interface EditExpenseForm {
   amount: string;
   due_date: string;
+  payment_method_id: string;
 }
 
 function EditExpenseModal({
@@ -384,6 +381,7 @@ function EditExpenseModal({
   onClose,
   expense,
   cycleId,
+  paymentMethods,
   currentUser,
   onEdited,
   onActivityChanged,
@@ -392,6 +390,7 @@ function EditExpenseModal({
   onClose: () => void;
   expense: CycleExpense | null;
   cycleId: string;
+  paymentMethods: PaymentMethod[];
   currentUser: UserResponse | null;
   onEdited: (updated: CycleExpense) => void;
   onActivityChanged?: () => void;
@@ -399,6 +398,7 @@ function EditExpenseModal({
   const [form, setForm] = useState<EditExpenseForm>({
     amount: "",
     due_date: "",
+    payment_method_id: "",
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -408,6 +408,7 @@ function EditExpenseModal({
   const initialFormRef = useRef<EditExpenseForm>({
     amount: "",
     due_date: "",
+    payment_method_id: "",
   });
 
   useEffect(() => {
@@ -415,6 +416,7 @@ function EditExpenseModal({
       const initial = {
         amount: expense.amount,
         due_date: expense.due_date ?? "",
+        payment_method_id: expense.payment_method_id ?? "",
       };
       setForm(initial);
       initialFormRef.current = initial;
@@ -425,7 +427,8 @@ function EditExpenseModal({
 
   const isDirty =
     form.amount !== initialFormRef.current.amount ||
-    form.due_date !== initialFormRef.current.due_date;
+    form.due_date !== initialFormRef.current.due_date ||
+    form.payment_method_id !== initialFormRef.current.payment_method_id;
 
   const handleAttemptClose = () => {
     if (isDirty) setConfirmDiscard(true);
@@ -442,6 +445,7 @@ function EditExpenseModal({
     const res = await editExpense(cycleId, expense.id, {
       amount: form.amount,
       due_date: form.due_date || null,
+      payment_method_id: form.payment_method_id || undefined,
     });
     if (res.success) {
       // Keep the modal open so the user can confirm the change landed in
@@ -452,6 +456,7 @@ function EditExpenseModal({
       initialFormRef.current = {
         amount: res.data.amount,
         due_date: res.data.due_date ?? "",
+        payment_method_id: res.data.payment_method_id ?? "",
       };
       setForm(initialFormRef.current);
       setActivityRefresh((n) => n + 1);
@@ -470,7 +475,12 @@ function EditExpenseModal({
     >
       <div
         className="nb-modal"
-        style={{ maxWidth: 640, width: "100%", maxHeight: "90vh", overflowY: "auto" }}
+        style={{
+          maxWidth: 640,
+          width: "100%",
+          maxHeight: "90vh",
+          overflowY: "auto",
+        }}
       >
         <button className="nb-modal-close" onClick={handleAttemptClose}>
           ✕
@@ -508,6 +518,25 @@ function EditExpenseModal({
             />
           </div>
         </div>
+
+        {paymentMethods.length > 0 && (
+          <div className="nb-form-group">
+            <label className="nb-form-label">Payment method</label>
+            <select
+              className="nb-form-select"
+              value={form.payment_method_id}
+              onChange={(e) => set("payment_method_id", e.target.value)}
+            >
+              {paymentMethods
+                .filter((m) => m.active)
+                .map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {formatPaymentMethodName(m)}
+                  </option>
+                ))}
+            </select>
+          </div>
+        )}
 
         {error && (
           <p
@@ -561,6 +590,7 @@ function EditExpenseModal({
             onActivityChanged?.();
           }}
           expenses={[expense]}
+          paymentMethods={paymentMethods}
         />
       </div>
       <DiscardChangesDialog
@@ -671,7 +701,12 @@ function EditIncomeModal({
     >
       <div
         className="nb-modal"
-        style={{ maxWidth: 640, width: "100%", maxHeight: "90vh", overflowY: "auto" }}
+        style={{
+          maxWidth: 640,
+          width: "100%",
+          maxHeight: "90vh",
+          overflowY: "auto",
+        }}
       >
         <button className="nb-modal-close" onClick={handleAttemptClose}>
           ✕
@@ -1679,10 +1714,7 @@ export function CycleDetail({
   const editExpenseOpen = !!editingExpense;
   const editIncomeOpen = !!editingIncome;
 
-  const setUrlParam = (
-    key: "expense" | "income",
-    value: string | null,
-  ) => {
+  const setUrlParam = (key: "expense" | "income", value: string | null) => {
     const params = new URLSearchParams(searchParams.toString());
     if (value) params.set(key, value);
     else params.delete(key);
@@ -1833,95 +1865,99 @@ export function CycleDetail({
         incomes.map((income) => {
           const editable = cycle.status !== "completed";
           return (
-          <div
-            key={income.id}
-            role={editable ? "button" : undefined}
-            tabIndex={editable ? 0 : undefined}
-            onClick={editable ? () => handleEditIncome(income) : undefined}
-            onKeyDown={
-              editable
-                ? (e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      handleEditIncome(income);
+            <div
+              key={income.id}
+              role={editable ? "button" : undefined}
+              tabIndex={editable ? 0 : undefined}
+              onClick={editable ? () => handleEditIncome(income) : undefined}
+              onKeyDown={
+                editable
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleEditIncome(income);
+                      }
                     }
-                  }
-                : undefined
-            }
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              padding: "6px 10px",
-              marginBottom: 4,
-              borderRadius: 4,
-              background: "rgba(80,200,100,0.10)",
-              border: "1px solid rgba(80,200,100,0.25)",
-              fontFamily: "var(--font-hand)",
-              cursor: editable ? "pointer" : "default",
-            }}
-          >
-            <span style={{ fontSize: 14, color: "var(--ink)", flex: 1 }}>
-              {income.description}
-            </span>
-            {income.template_id ? (
+                  : undefined
+              }
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "6px 10px",
+                marginBottom: 4,
+                borderRadius: 4,
+                background: "rgba(80,200,100,0.10)",
+                border: "1px solid rgba(80,200,100,0.25)",
+                fontFamily: "var(--font-hand)",
+                cursor: editable ? "pointer" : "default",
+              }}
+            >
+              <span style={{ fontSize: 14, color: "var(--ink)", flex: 1 }}>
+                {income.description}
+              </span>
+              {income.template_id ? (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "var(--ink-light)",
+                    opacity: 0.6,
+                    background: "rgba(44,74,62,0.08)",
+                    borderRadius: 3,
+                    padding: "1px 5px",
+                  }}
+                >
+                  recurring
+                </span>
+              ) : (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "var(--ink-light)",
+                    opacity: 0.6,
+                    background: "rgba(201,168,76,0.12)",
+                    borderRadius: 3,
+                    padding: "1px 5px",
+                  }}
+                >
+                  manual
+                </span>
+              )}
+              <span
+                style={{ fontSize: 13, color: "var(--ink)", fontWeight: 700 }}
+              >
+                {fmtAmount(income.amount, income.currency)}
+              </span>
               <span
                 style={{
-                  fontSize: 11,
+                  fontSize: 12,
                   color: "var(--ink-light)",
-                  opacity: 0.6,
-                  background: "rgba(44,74,62,0.08)",
-                  borderRadius: 3,
-                  padding: "1px 5px",
+                  opacity: 0.55,
                 }}
               >
-                recurring
+                {fmtDate(income.income_date)}
               </span>
-            ) : (
-              <span
-                style={{
-                  fontSize: 11,
-                  color: "var(--ink-light)",
-                  opacity: 0.6,
-                  background: "rgba(201,168,76,0.12)",
-                  borderRadius: 3,
-                  padding: "1px 5px",
-                }}
-              >
-                manual
-              </span>
-            )}
-            <span
-              style={{ fontSize: 13, color: "var(--ink)", fontWeight: 700 }}
-            >
-              {fmtAmount(income.amount, income.currency)}
-            </span>
-            <span
-              style={{ fontSize: 12, color: "var(--ink-light)", opacity: 0.55 }}
-            >
-              {fmtDate(income.income_date)}
-            </span>
-            {editable && (
-              <button
-                style={{
-                  background: "transparent",
-                  border: "none",
-                  cursor: "pointer",
-                  color: "var(--ink-light)",
-                  fontSize: 14,
-                  padding: "0 4px",
-                  opacity: 0.5,
-                }}
-                title="Remove income"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onIncomeRemoved(income.id);
-                }}
-              >
-                ✕
-              </button>
-            )}
-          </div>
+              {editable && (
+                <button
+                  style={{
+                    background: "transparent",
+                    border: "none",
+                    cursor: "pointer",
+                    color: "var(--ink-light)",
+                    fontSize: 14,
+                    padding: "0 4px",
+                    opacity: 0.5,
+                  }}
+                  title="Remove income"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onIncomeRemoved(income.id);
+                  }}
+                >
+                  ✕
+                </button>
+              )}
+            </div>
           );
         })
       ) : (
@@ -2027,6 +2063,7 @@ export function CycleDetail({
         onClose={closeEditExpense}
         expense={editingExpense}
         cycleId={cycle.id}
+        paymentMethods={paymentMethods}
         currentUser={currentUser ?? null}
         onEdited={onExpenseEdited}
         onActivityChanged={onActivityChanged}

--- a/mcp-server/colony_mcp/tools/expenses.py
+++ b/mcp-server/colony_mcp/tools/expenses.py
@@ -418,6 +418,7 @@ async def update_cycle_expense(
     amount: float | None = None,
     due_date: str | None = None,
     category: str | None = None,
+    payment_method_id: str | None = None,
     comments: str | None = None,
     paid: bool | None = None,
 ) -> dict[str, Any]:
@@ -433,6 +434,8 @@ async def update_cycle_expense(
         amount: New amount, if changing it.
         due_date: New due date (YYYY-MM-DD), if changing it.
         category: New category (fixed/variable/extra), if changing it.
+        payment_method_id: New payment method UUID, if changing it. Use
+            ``list_payment_methods`` to find a valid id.
         comments: New comment text, if changing it.
         paid: New paid flag, if changing it.
     """
@@ -444,6 +447,7 @@ async def update_cycle_expense(
             "amount": amount,
             "due_date": due_date,
             "category": category,
+            "payment_method_id": payment_method_id,
             "comments": comments,
             "paid": paid,
         }.items()


### PR DESCRIPTION
## Context

Once a cycle is generated, each expense's payment method is copied from its
recurrent-expense template and could no longer be changed — users could edit
the amount, due date, and comments, but not the payment method. This is a
valid use case (e.g. a bill paid with a different card this month).

Investigation showed this was **not a hard API limitation**, just a missing
field across the schema, MCP tool, and UI. Scope: **expenses only**.

## Changes

- **Backend**
  - Add `payment_method_id` to `CycleExpenseUpdate`, validated via the
    existing `_verify_payment_method` (rejects unknown / cross-household ids
    with 404). The generic `update_expense` already applies the field and
    logs the diff to the activity log.
  - Add `payment_method_id` to `CycleExpenseResponse` so the UI can
    re-initialize its dropdown after save (fixes the dropdown reverting to
    the first option even though the change was persisted).
- **MCP**: expose `payment_method_id` on `update_cycle_expense`
  (valid ids discoverable via `list_payment_methods`).
- **Frontend**: payment-method dropdown in `EditExpenseModal`; the activity
  feed resolves `payment_method_id` diffs to readable names instead of raw
  UUIDs.
- **Docs**: `api-specification.md` and `mcp-server.md` updated.

## Database

No DB changes — the `payment_method_id` column already exists on
`CycleExpense`. No models touched, no migrations.

## Tests

New `backend/tests/cycles/test_expense_update.py`:
- requires auth
- happy path (asserts both `payment_method_id` and nested `payment_method`)
- unknown payment method rejected (404)
- cross-household payment method rejected (404)
- change recorded in the activity log

Validation: backend ruff/pyright clean, **160 tests pass**; frontend
`tsc --noEmit` clean; MCP ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)